### PR TITLE
Fix OSX 10.12 and onward compilation issue

### DIFF
--- a/compat/clock_gettime/clock_gettime.c
+++ b/compat/clock_gettime/clock_gettime.c
@@ -58,7 +58,8 @@
  *
  */
 
-
+#include <time.h>
+#ifndef CLOCK_REALTIME
 #include "clock_gettime.h"
 #include <mach/clock.h>             // for clock_get_time
 #include <mach/clock_types.h>       // for mach_timespec_t, CALENDAR_CLOCK, etc
@@ -134,3 +135,4 @@ int clock_gettime(clockid_t clk_id, struct timespec *tp)
     }
     return retval;
 }
+#endif

--- a/compat/clock_gettime/clock_gettime.h
+++ b/compat/clock_gettime/clock_gettime.h
@@ -1,10 +1,10 @@
 #ifndef CLOCK_GETTIME_H
 #define CLOCK_GETTIME_H
 
+#include <time.h>
 #include <mach/mach_time.h>
 
-#ifndef CLOCKID_T
-#define CLOCKID_T
+#ifndef CLOCK_REALTIME
 typedef enum
 {
     CLOCK_REALTIME,
@@ -12,12 +12,11 @@ typedef enum
     CLOCK_PROCESS_CPUTIME_ID,
     CLOCK_THREAD_CPUTIME_ID
 } clockid_t;
-#endif // CLOCKID_T
 
 struct timespec;
 
 static mach_timebase_info_data_t __clock_gettime_inf;
 
 int clock_gettime(clockid_t clk_id, struct timespec *tp);
-
+#endif // CLOCK_REALTIME
 #endif // CLOCK_GETTIME_H

--- a/compat/clock_nanosleep/clock_nanosleep.h
+++ b/compat/clock_nanosleep/clock_nanosleep.h
@@ -1,8 +1,9 @@
 #ifndef CLOCK_NANOSLEEP_H
 #define CLOCK_NANOSLEEP_H
 
-#ifndef CLOCKID_T
-#define CLOCKID_T
+#include <time.h>
+
+#ifndef CLOCK_REALTIME
 typedef enum
 {
     CLOCK_REALTIME,
@@ -10,7 +11,7 @@ typedef enum
     CLOCK_PROCESS_CPUTIME_ID,
     CLOCK_THREAD_CPUTIME_ID
 } clockid_t;
-#endif // CLOCKID_T
+#endif //CLOCK_REALTIME
 
 #ifndef TIMER_ABSTIME
 #define TIMER_ABSTIME 1


### PR DESCRIPTION
On OS X 10.12 an onward clockid_t exists as well as the clock_gettime implementation. This PR fixes this by detection those definitions.