### PR TITLE
Fixed compilation with Gcc 7

### DIFF
--- a/interactive.c
+++ b/interactive.c
@@ -137,7 +137,7 @@ void interactiveShowData(void) {
                 if (Modes.interactive_rtl1090) { // RTL1090 display mode
 
                     if (a->bFlags & MODES_ACFLAGS_ALTITUDE_VALID) {
-                        snprintf(strFl,6,"F%03d",(a->altitude/100));
+                        snprintf(strFl,6,"F%03d",(a->altitude/100) % 999);
                     }
                     printf("%06x %-8s %-4s         %-3s %-3s %4s        %-6d  %-2.0f\n", 
                            a->addr, a->flight, strFl, strGs, strTt, strSquawk, msgs, (now - a->seen)/1000.0);

--- a/net_io.c
+++ b/net_io.c
@@ -756,24 +756,28 @@ static void modesSendStratuxOutput(struct modesMessage *mm, struct aircraft *a) 
     else                                         {p += sprintf(p, "\"Squawk\":null,");}    
     
     // Emitter type
-	int emitter = 0;
-	int setEmitter = 0;
-	if ((mm->msgtype ==  17) || (mm->msgtype = 18)) {
-		switch (mm->metype) {
-			case 1:
-				emitter = ((mm->mesub) | 0x18);
-				setEmitter = 1;
-			case 2:
-				emitter = ((mm->mesub) | 0x10);
-				setEmitter = 1;
-			case 3:
-				emitter = ((mm->mesub) | 0x08);
-				setEmitter = 1;
-			case 4:
-				emitter = (mm->mesub);
-				setEmitter = 1;
-		}
-	}
+    int emitter = 0;
+    int setEmitter = 0;
+    if ((mm->msgtype ==  17) || (mm->msgtype = 18)) {
+        switch (mm->metype) {
+            case 1:
+                emitter = ((mm->mesub) | 0x18);
+                setEmitter = 1;
+                break;
+            case 2:
+                emitter = ((mm->mesub) | 0x10);
+                setEmitter = 1;
+                break;
+            case 3:
+                emitter = ((mm->mesub) | 0x08);
+                setEmitter = 1;
+                break;
+            case 4:
+                emitter = (mm->mesub);
+                setEmitter = 1;
+                break;
+        }
+    }
 
     if ((mm->msgtype == 32) && (mm->fs & 0x0080)) {
         // Mode-A/Mode-C "IDENT" flag.


### PR DESCRIPTION
Hi
GCC7 (Debian Buster) seems to be less tolerant with respect to possible errors.
Namely:
```
interactive.c:140:44: error: ‘%03d’ directive output may be truncated writing between 3 and 9 bytes into a region of size 5 [-Werror=format-truncation=]
                         snprintf(strFl,6,"F%03d",(a->altitude/100));
                                            ^~~~
interactive.c:140:42: note: directive argument in the range [-21474836, 21474836]
                         snprintf(strFl,6,"F%03d",(a->altitude/100));
```

and
```
gcc -DMODES_DUMP1090_VERSION=\"\" -O2 -g -Wall -Werror -W `pkg-config --cflags librtlsdr`  -c net_io.c -o net_io.o
net_io.c: In function ‘modesSendStratuxOutput’:
net_io.c:765:16: error: this statement may fall through [-Werror=implicit-fallthrough=]
     setEmitter = 1;
     ~~~~~~~~~~~^~~
net_io.c:766:4: note: here
    case 2:
    ^~~~
net_io.c:768:16: error: this statement may fall through [-Werror=implicit-fallthrough=]
     setEmitter = 1;
     ~~~~~~~~~~~^~~
net_io.c:769:4: note: here
    case 3:
    ^~~~
net_io.c:771:16: error: this statement may fall through [-Werror=implicit-fallthrough=]
     setEmitter = 1;
     ~~~~~~~~~~~^~~
net_io.c:772:4: note: here
    case 4:

```
We could disable these errors in the makefile, but I guess it makes more sense to do a proper fix.

About the first one, I simply made sure that the compiler is happy by taking the altitude modulo 999. As long as the alt is in a valid range, that should not change anything.

The second one is a bit more tricky, as I am not quite sure what the code does. My change
- fixes the indentation (tabs were used instead of spaces as in the rest of the file)
- changes the behaviour of the switch. I do not know what the code is supposed to do, but simply applying logic to what happened earlier makes me think that the break statements were simply forgotten (thank you GCC?).
If the code is indeed meant to be like it was before, it could be simplified drastically, since all cases will effectively evaluate to `emitter = mm->mesub; setEmitter = 1` (the last case). Am I wrong about this assumption?